### PR TITLE
JWT user prop er caller, ikke upn

### DIFF
--- a/handlers/frontpage.js
+++ b/handlers/frontpage.js
@@ -3,7 +3,7 @@ const { logger } = require('@vtfk/logger')
 const { readFileSync } = require('fs')
 
 module.exports = (req, res) => {
-  const caller = (req.user && req.user.upn) || req.headers['x-forwarded-for'] || req.socket.remoteAddress
+  const caller = (req.user && req.user.caller) || req.headers['x-forwarded-for'] || req.socket.remoteAddress
   logger('debug', ['frontpage', caller, 'returning'])
 
   const usage = readFileSync('USAGE.md', 'utf-8')

--- a/handlers/invoke-ps.js
+++ b/handlers/invoke-ps.js
@@ -5,7 +5,7 @@ const invokePSFile = require('../lib/invoke-ps-file')
 const isValidJSON = require('../lib/is-valid-json')
 
 module.exports = (req, res) => {
-  const caller = (req.user && req.user.upn) || req.headers['x-forwarded-for'] || req.socket.remoteAddress
+  const caller = (req.user && req.user.caller) || req.headers['x-forwarded-for'] || req.socket.remoteAddress
   const { body } = req
 
   if (!body) {

--- a/handlers/invoke-service.js
+++ b/handlers/invoke-service.js
@@ -7,7 +7,7 @@ const config = require('../config')
 const { logger } = require('@vtfk/logger')
 
 module.exports = (req, res) => {
-  const caller = (req.user && req.user.upn) || req.headers['x-forwarded-for'] || req.socket.remoteAddress
+  const caller = (req.user && req.user.caller) || req.headers['x-forwarded-for'] || req.socket.remoteAddress
   const { body } = req
 
   if (!body) {


### PR DESCRIPTION
JWT-nøkkelen inneholder `caller` for å identifisere brukeren, ikke `upn` som først antatt. 